### PR TITLE
Side nav focus states

### DIFF
--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -28,6 +28,11 @@
     }
   }
 
+  .euiListGroupItem__button:focus {
+    background-color: $euiFocusBackgroundColor;
+    border-radius: $euiBorderRadius;
+  }
+
   .euiListGroupItem__label {
     line-height: $euiSize;
   }
@@ -63,7 +68,7 @@
         height: 0;
       }
 
-      .euiListGroupItem__button {
+      .euiListGroup:not(.euiNavDrawer__expandButton) .euiListGroupItem__button {
         max-width: $euiSizeXL;
       }
     }


### PR DESCRIPTION
I think I accidentally deleted some. So here I put them back but using focus background color variable and I rounded the corners of the button so when focusing on just the button part, all 4 corners were rounded.

**hover**

https://www.dropbox.com/s/wplg8g448qigdld/Screen%20Capture%20on%202019-03-11%20at%2015.06.31.1.mov?dl=0

**focus**

https://www.dropbox.com/s/49mt1pc6zs72k2e/Screen%20Capture%20on%202019-03-11%20at%2015.07.11.mov?dl=0